### PR TITLE
Feature/driver - DeviceDriver read(), write() 구현

### DIFF
--- a/Project41.sln
+++ b/Project41.sln
@@ -7,6 +7,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Project41", "Project41\Proj
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Sample-Test1", "Sample-Test1\Sample-Test1.vcxproj", "{887092B0-CEF8-4939-BBB0-C3F82C2C18FA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "솔루션 항목", "솔루션 항목", "{742394AF-7480-48EE-B263-9A5BFF7910C3}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/Project41/DeviceDriver.cpp
+++ b/Project41/DeviceDriver.cpp
@@ -7,13 +7,14 @@ DeviceDriver::DeviceDriver(FlashMemoryDevice* hardware) : m_hardware(hardware)
 
 int DeviceDriver::read(long address)
 {
-    // TODO: implement this method properly
-    m_hardware->read(address);
-    m_hardware->read(address);
-    m_hardware->read(address);
-    m_hardware->read(address);
-    m_hardware->read(address);
-    return 0;
+    std::unordered_set<int> readResults;
+    for (int i = 0; i < 5; i++) {
+        readResults.insert((int)(m_hardware->read(address)));
+    }
+    if (readResults.size() != 1) {
+        return 0;
+    }
+    return *readResults.begin();
 }
 
 void DeviceDriver::write(long address, int data)

--- a/Project41/DeviceDriver.cpp
+++ b/Project41/DeviceDriver.cpp
@@ -1,4 +1,6 @@
 #include "DeviceDriver.h"
+#include <unordered_set>
+
 
 DeviceDriver::DeviceDriver(FlashMemoryDevice* hardware) : m_hardware(hardware)
 {}
@@ -6,7 +8,12 @@ DeviceDriver::DeviceDriver(FlashMemoryDevice* hardware) : m_hardware(hardware)
 int DeviceDriver::read(long address)
 {
     // TODO: implement this method properly
-    return (int)(m_hardware->read(address));
+    m_hardware->read(address);
+    m_hardware->read(address);
+    m_hardware->read(address);
+    m_hardware->read(address);
+    m_hardware->read(address);
+    return 0;
 }
 
 void DeviceDriver::write(long address, int data)

--- a/Project41/DeviceDriver.cpp
+++ b/Project41/DeviceDriver.cpp
@@ -1,6 +1,21 @@
 #include "DeviceDriver.h"
 #include <unordered_set>
+#include <stdexcept>
+#include <string>
 
+class ReadFailException : public std::exception {
+public:
+    ReadFailException(const char* msg)
+        : message(msg) {
+
+    }
+    const char* what() const throw() {
+        return message.c_str();
+    }
+
+private:
+    std::string message;
+};
 
 DeviceDriver::DeviceDriver(FlashMemoryDevice* hardware) : m_hardware(hardware)
 {}
@@ -12,7 +27,7 @@ int DeviceDriver::read(long address)
         readResults.insert((int)(m_hardware->read(address)));
     }
     if (readResults.size() != 1) {
-        return 0;
+        throw ReadFailException("FlashMemoryDevice returns different value in 5 times.");
     }
     return *readResults.begin();
 }

--- a/Project41/DeviceDriver.cpp
+++ b/Project41/DeviceDriver.cpp
@@ -17,6 +17,20 @@ private:
     std::string message;
 };
 
+class WriteFailException : public std::exception {
+public:
+    WriteFailException(const char* msg)
+        : message(msg) {
+
+    }
+    const char* what() const throw() {
+        return message.c_str();
+    }
+
+private:
+    std::string message;
+};
+
 DeviceDriver::DeviceDriver(FlashMemoryDevice* hardware) : m_hardware(hardware)
 {}
 
@@ -34,12 +48,13 @@ int DeviceDriver::read(long address)
 
 void DeviceDriver::write(long address, int data)
 {
-    if (isEmptyAddress(address)) {
-        m_hardware->write(address, (unsigned char)data);
+    if (isOkayToWrite(address) == false) {
+        throw WriteFailException("FlashMemoryDevice is written so cannot be written again.");
     }
+    m_hardware->write(address, (unsigned char)data);
 }
 
-bool DeviceDriver::isEmptyAddress(long address)
+bool DeviceDriver::isOkayToWrite(long address)
 {
     unsigned char data;
     try {

--- a/Project41/DeviceDriver.cpp
+++ b/Project41/DeviceDriver.cpp
@@ -34,6 +34,21 @@ int DeviceDriver::read(long address)
 
 void DeviceDriver::write(long address, int data)
 {
-    // TODO: implement this method
-    m_hardware->write(address, (unsigned char)data);
+    if (isEmptyAddress(address)) {
+        m_hardware->write(address, (unsigned char)data);
+    }
+}
+
+bool DeviceDriver::isEmptyAddress(long address)
+{
+    unsigned char data;
+    try {
+        data = m_hardware->read(address);
+    }
+    catch (ReadFailException& e) {
+        return false;
+    }
+
+    if (data == 0xFF)    return true;
+    return false;
 }

--- a/Project41/DeviceDriver.h
+++ b/Project41/DeviceDriver.h
@@ -7,7 +7,7 @@ public:
     DeviceDriver(FlashMemoryDevice* hardware);
     int read(long address);
     void write(long address, int data);
-    bool isEmptyAddress(long address);
+    bool isOkayToWrite(long address);
 
 protected:
     FlashMemoryDevice* m_hardware;

--- a/Project41/DeviceDriver.h
+++ b/Project41/DeviceDriver.h
@@ -7,6 +7,7 @@ public:
     DeviceDriver(FlashMemoryDevice* hardware);
     int read(long address);
     void write(long address, int data);
+    bool isEmptyAddress(long address);
 
 protected:
     FlashMemoryDevice* m_hardware;

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -9,58 +9,47 @@ public:
 	MOCK_METHOD(void, write, (long, unsigned char), (override));
 };
 
-TEST(TestCaseName, Flash에서Read가5번호출되어야PASS) {
+class TestFixture : public testing::Test {
+public:
 	MockFlashMemoryDevice mk;
+	DeviceDriver dd{ &mk };
+};
 
+TEST_F(TestFixture, Flash에서Read가5번호출되어야PASS) {
 	EXPECT_CALL(mk, read, (0xA), ())
 		.Times(5);
 
-	DeviceDriver dd{ &mk };
 	dd.read(0xA);
 }
 
-TEST(TestCaseName, Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION) {
-	MockFlashMemoryDevice mk;
-
+TEST_F(TestFixture, Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION) {
 	EXPECT_CALL(mk, read, (0xA), ())
 		.WillOnce(testing::Return(1))
 		.WillRepeatedly(testing::Return(2));
-
-	DeviceDriver dd{ &mk };
 
 	EXPECT_THROW({
 		dd.read(0xA);
 		}, ReadFailException);
 }
 
-TEST(TestCaseName, Write전에비어있는지Read해야함) {
-	MockFlashMemoryDevice mk;
-
+TEST_F(TestFixture, Write전에비어있는지Read해야함) {
 	EXPECT_CALL(mk, read, (0xA), ())
 		.Times(1)
 		.WillRepeatedly(testing::Return(0xFF)); // Avoid exception in dd.write()
 
-	DeviceDriver dd{ &mk };
 	dd.write(0xA, 'A');
 }
 
-TEST(TestCaseName, Write할때비어있어서PASS) {
-	MockFlashMemoryDevice mk;
-
+TEST_F(TestFixture, Write할때비어있어서PASS) {
 	EXPECT_CALL(mk, read)
 		.WillRepeatedly(testing::Return(0xFF));
 
-	DeviceDriver dd{ &mk };
 	dd.write(0xA, 'A');
 }
 
-TEST(TestCaseName, Write할때비어있지않아서EXCEPTION) {
-	MockFlashMemoryDevice mk;
-
+TEST_F(TestFixture, Write할때비어있지않아서EXCEPTION) {
 	EXPECT_CALL(mk, read, (0xA), ())
 		.WillRepeatedly(testing::Return('B'));
-
-	DeviceDriver dd{ &mk };
 
 	EXPECT_THROW({
 		dd.write(0xA, 'A');

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -32,3 +32,14 @@ TEST(TestCaseName, Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION) {
 		dd.read(0xA);
 		}, ReadFailException);
 }
+
+TEST(TestCaseName, Write전에비어있는지Read해야함) {
+	MockFlashMemoryDevice mk;
+
+	EXPECT_CALL(mk, read)
+		.Times(1);
+		//.WillRepeatedly(testing::Return(0xFF));
+
+	DeviceDriver dd{ &mk };
+	dd.write(0xA, 'A');
+}

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -36,10 +36,33 @@ TEST(TestCaseName, Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION) {
 TEST(TestCaseName, Write전에비어있는지Read해야함) {
 	MockFlashMemoryDevice mk;
 
-	EXPECT_CALL(mk, read)
-		.Times(1);
-		//.WillRepeatedly(testing::Return(0xFF));
+	EXPECT_CALL(mk, read, (0xA), ())
+		.Times(1)
+		.WillRepeatedly(testing::Return(0xFF)); // Avoid exception in dd.write()
 
 	DeviceDriver dd{ &mk };
 	dd.write(0xA, 'A');
+}
+
+TEST(TestCaseName, Write할때비어있어서PASS) {
+	MockFlashMemoryDevice mk;
+
+	EXPECT_CALL(mk, read)
+		.WillRepeatedly(testing::Return(0xFF));
+
+	DeviceDriver dd{ &mk };
+	dd.write(0xA, 'A');
+}
+
+TEST(TestCaseName, Write할때비어있지않아서EXCEPTION) {
+	MockFlashMemoryDevice mk;
+
+	EXPECT_CALL(mk, read, (0xA), ())
+		.WillRepeatedly(testing::Return('B'));
+
+	DeviceDriver dd{ &mk };
+
+	EXPECT_THROW({
+		dd.write(0xA, 'A');
+		}, WriteFailException);
 }

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -18,3 +18,17 @@ TEST(TestCaseName, Flash에서Read가5번호출되어야PASS) {
 	DeviceDriver dd{ &mk };
 	dd.read(0xA);
 }
+
+TEST(TestCaseName, Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION) {
+	MockFlashMemoryDevice mk;
+
+	EXPECT_CALL(mk, read, (0xA), ())
+		.WillOnce(testing::Return(1))
+		.WillRepeatedly(testing::Return(2));
+
+	DeviceDriver dd{ &mk };
+
+	EXPECT_THROW({
+		dd.read(0xA);
+		}, ReadFailException);
+}

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -1,8 +1,20 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "../Project41/FlashMemoryDevice.h"
+#include "../Project41/DeviceDriver.cpp"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
-  EXPECT_THAT(1, 1);
+class MockFlashMemoryDevice : public FlashMemoryDevice {
+public:
+	MOCK_METHOD(unsigned char, read, (long), (override));
+	MOCK_METHOD(void, write, (long, unsigned char), (override));
+};
+
+TEST(TestCaseName, Flash에서Read가5번호출되어야PASS) {
+	MockFlashMemoryDevice mk;
+
+	EXPECT_CALL(mk, read, (0xA), ())
+		.Times(5);
+
+	DeviceDriver dd{ &mk };
+	dd.read(0xA);
 }


### PR DESCRIPTION
## 테스트 결과
```bash
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from TestFixture
[ RUN      ] TestFixture.Flash에서Read가5번호출되어야PASS
[       OK ] TestFixture.Flash에서Read가5번호출되어야PASS (0 ms)
[ RUN      ] TestFixture.Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION
[       OK ] TestFixture.Flash에서Read가5번중다르게리턴하는게있으면EXCEPTION (0 ms)
[ RUN      ] TestFixture.Write전에비어있는지Read해야함

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: write(10, 'A' (65, 0x41))
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
[       OK ] TestFixture.Write전에비어있는지Read해야함 (0 ms)
[ RUN      ] TestFixture.Write할때비어있어서PASS

GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: write(10, 'A' (65, 0x41))
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.
[       OK ] TestFixture.Write할때비어있어서PASS (0 ms)
[ RUN      ] TestFixture.Write할때비어있지않아서EXCEPTION
[       OK ] TestFixture.Write할때비어있지않아서EXCEPTION (0 ms)
[----------] 5 tests from TestFixture (2 ms total)
[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.
```